### PR TITLE
Additional checks for invalid inputs to parseInt

### DIFF
--- a/admittance.js
+++ b/admittance.js
@@ -56,7 +56,7 @@ var checkAccess = function (permissions, assignments, userid, permission) {
 
 var checkExpression = function (userid, expression) {
   var success = true;
-  if (parseInt(expression).toString() !== 'NaN')
+  if ((expression || expression === 0) && parseInt(expression).toString() !== 'NaN')
     success = (parseInt(expression, 10) === parseInt(userid, 10))
   if (typeof expression === 'boolean')
     success = expression


### PR DESCRIPTION
Some version of chrome (I forget which one) throws an error on `parseInt(undefined)` instead of returning `NaN` like it should.

This change adds manual checks for undefined into `parseInt` to protect against uncaught errors.